### PR TITLE
Remove data variable from remover example

### DIFF
--- a/docs/ActionsCreators.md
+++ b/docs/ActionsCreators.md
@@ -71,7 +71,7 @@ const todosActions = actions({
     .catch(response => handleError())
   },
   remover: (id, handleSuccess, handleError) => {
-    return axios.delete(`todos/${id}`, data)
+    return axios.delete(`todos/${id}`)
     .then(response => handleSuccess())
     .catch(response => handleError())
   }


### PR DESCRIPTION
The example given for the `remover` action contains a `data` variable which is undefined (and unused), so should be removed.